### PR TITLE
Add zstandard decompression support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ uvloop
 uvicorn
 starlette
 aiohttp
+backports.zstd ; python_version < '3.14'
 validators
 platformdirs
 tomli >= 1.1.0; python_version < '3.11'


### PR DESCRIPTION
Servers increasingly use zstandard (zstd) compression for HTTP responses, supported by ~80% of browsers. Without zstd support, corsproxy crashes when encountering these responses with a `ContentEncodingError` from aiohttp.

This PR adds the `backports.zstd` package as a conditional dependency, enabling aiohttp to automatically decompress zstd-encoded responses. The dependency is only installed for Python < 3.14; Python 3.14+ includes zstd support in the standard library.

## Changes
- Added `backports.zstd ; python_version < '3.14'` to `requirements.txt`

## Impact
- No code changes needed - aiohttp automatically uses the decompressor when available
- Works for both Docker deployments (Python 3.13) and standalone installations
- Users no longer need workarounds like setting `Accept-Encoding: identity` headers

Fixes: #8