### PR TITLE
Fix Host header forwarding to support reverse proxy usage

### DIFF
--- a/corsproxy
+++ b/corsproxy
@@ -64,7 +64,10 @@ async def get(request: Request) -> Response:
     url = urlunsplit(urlsplit(str(request.url))._replace(scheme='', netloc=''))
 
     method = request.method
-    hdr = request.headers
+    # Create mutable copy of headers and remove Host header so aiohttp
+    # sets it correctly based on the target URL instead of forwarding
+    # the client's Host header
+    hdr = {k: v for k, v in request.headers.items() if k.lower() != 'host'}
 
     if method == 'GET':
         func = session.get(url, headers=hdr)


### PR DESCRIPTION
When corsproxy is deployed behind a reverse proxy (like Traefik), the incoming request's Host header points to the proxy's hostname rather than the target server's hostname. Previously, corsproxy would forward this Host header unchanged, causing many target servers to respond with 404 errors because they didn't recognize the proxy's hostname in their virtual host configuration.

This PR modifies the request forwarding logic to filter out the Host header before sending requests to the target server. This allows aiohttp to automatically set the correct Host header based on the target URL, ensuring that target servers receive the hostname they expect.

## Changes

- Modified the `get()` function in `corsproxy` to filter out the Host header (case-insensitively) from forwarded requests
- The change is minimal and surgical - a single line modification that preserves all other header forwarding behavior

## Benefits

- Fixes 404 errors when corsproxy is used behind reverse proxies
- Users no longer need to manually configure Host header overrides in their reverse proxy setup
- Maintains backward compatibility with existing deployments
- Follows HTTP/1.1 standards where the Host header should match the target server

Fixes: #9